### PR TITLE
feat: introduce server architecture with error handling

### DIFF
--- a/ttl_server/src/app.ts
+++ b/ttl_server/src/app.ts
@@ -1,21 +1,17 @@
-import express, { Request, Response } from 'express';
-import { z } from 'zod';
+import express from 'express';
+
+import { errorHandler } from './lib/errors.js';
+import { notFound } from './lib/notFound.js';
+import { requestIdLogger } from './lib/requestIdLogger.js';
+import healthRoutes from './routes/healthRoutes.js';
+import itemsRoutes from './routes/itemsRoutes.js';
 
 const app = express();
+app.use(requestIdLogger);
 app.use(express.json());
-
-// health
-app.get('/health', (_req: Request, res: Response) => {
-  res.status(200).json({ ok: true });
-});
-
-// voorbeeld route met validatie
-const IdParam = z.object({ id: z.string().uuid() });
-app.get('/items/:id', (req: Request, res: Response) => {
-  const parsed = IdParam.safeParse(req.params);
-  if (!parsed.success) return res.status(400).json({ error: 'invalid id' });
-  // later: service call
-  return res.json({ id: parsed.data.id });
-});
+app.use(healthRoutes);
+app.use(itemsRoutes);
+app.use(notFound);
+app.use(errorHandler);
 
 export default app;

--- a/ttl_server/src/controllers/healthController.ts
+++ b/ttl_server/src/controllers/healthController.ts
@@ -1,0 +1,16 @@
+import { Request, Response, NextFunction } from 'express';
+
+import * as healthService from '../services/healthService.js';
+
+export async function getHealth(
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const result = await healthService.check();
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/ttl_server/src/controllers/itemsController.ts
+++ b/ttl_server/src/controllers/itemsController.ts
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction } from 'express';
+
+import * as itemService from '../services/itemService.js';
+
+export async function getItem(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { id } = req.params as { id: string };
+    const item = await itemService.getById(id);
+    res.json(item);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/ttl_server/src/lib/errors.ts
+++ b/ttl_server/src/lib/errors.ts
@@ -1,0 +1,30 @@
+import { Request, Response, NextFunction } from 'express';
+import { ZodError } from 'zod';
+
+export class HttpError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+export function errorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  _next: NextFunction,
+): void {
+  if (err instanceof HttpError) {
+    res.status(err.status).json({ error: err.message });
+    return;
+  }
+  if (err instanceof ZodError) {
+    res.status(400).json({ error: err.message });
+    return;
+  }
+  // eslint-disable-next-line no-console
+  console.error(err);
+  res.status(500).json({ error: 'internal server error' });
+}

--- a/ttl_server/src/lib/express.d.ts
+++ b/ttl_server/src/lib/express.d.ts
@@ -1,0 +1,10 @@
+declare global {
+  namespace Express {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface Request {
+      id: string;
+    }
+  }
+}
+
+export {};

--- a/ttl_server/src/lib/notFound.ts
+++ b/ttl_server/src/lib/notFound.ts
@@ -1,0 +1,5 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function notFound(_req: Request, res: Response, _next: NextFunction): void {
+  res.status(404).json({ error: 'not found' });
+}

--- a/ttl_server/src/lib/requestIdLogger.ts
+++ b/ttl_server/src/lib/requestIdLogger.ts
@@ -1,0 +1,12 @@
+import { randomUUID } from 'crypto';
+
+import { Request, Response, NextFunction } from 'express';
+
+export function requestIdLogger(req: Request, res: Response, next: NextFunction): void {
+  const id = randomUUID();
+  req.id = id;
+  res.setHeader('X-Request-Id', id);
+  // eslint-disable-next-line no-console
+  console.log(`[${id}] ${req.method} ${req.originalUrl}`);
+  next();
+}

--- a/ttl_server/src/lib/validation.ts
+++ b/ttl_server/src/lib/validation.ts
@@ -1,0 +1,21 @@
+import { Request, Response, NextFunction } from 'express';
+import { ZodSchema } from 'zod';
+
+import { HttpError } from './errors.js';
+
+export function validate(
+  schema: ZodSchema,
+  location: 'body' | 'query' | 'params' = 'body',
+) {
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    const reqRecord = req as unknown as Record<string, unknown>;
+    const data = reqRecord[location];
+    const result = schema.safeParse(data);
+    if (!result.success) {
+      next(new HttpError(400, result.error.message));
+      return;
+    }
+    reqRecord[location] = result.data as unknown;
+    next();
+  };
+}

--- a/ttl_server/src/repositories/itemRepository.ts
+++ b/ttl_server/src/repositories/itemRepository.ts
@@ -1,0 +1,12 @@
+export interface Item {
+  id: string;
+}
+
+const items = new Map<string, Item>();
+items.set('123e4567-e89b-12d3-a456-426614174000', {
+  id: '123e4567-e89b-12d3-a456-426614174000',
+});
+
+export async function findById(id: string): Promise<Item | null> {
+  return items.get(id) ?? null;
+}

--- a/ttl_server/src/routes/healthRoutes.ts
+++ b/ttl_server/src/routes/healthRoutes.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { z } from 'zod';
+
+import { getHealth } from '../controllers/healthController.js';
+import { validate } from '../lib/validation.js';
+
+const router = Router();
+const Empty = z.object({});
+router.get('/health', validate(Empty, 'query'), getHealth);
+
+export default router;

--- a/ttl_server/src/routes/itemsRoutes.ts
+++ b/ttl_server/src/routes/itemsRoutes.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { z } from 'zod';
+
+import { getItem } from '../controllers/itemsController.js';
+import { validate } from '../lib/validation.js';
+
+const router = Router();
+const IdParam = z.object({ id: z.string().uuid() });
+router.get('/items/:id', validate(IdParam, 'params'), getItem);
+
+export default router;

--- a/ttl_server/src/services/healthService.ts
+++ b/ttl_server/src/services/healthService.ts
@@ -1,0 +1,3 @@
+export async function check(): Promise<{ ok: boolean }> {
+  return { ok: true };
+}

--- a/ttl_server/src/services/itemService.ts
+++ b/ttl_server/src/services/itemService.ts
@@ -1,0 +1,10 @@
+import { HttpError } from '../lib/errors.js';
+import * as repository from '../repositories/itemRepository.js';
+
+export async function getById(id: string) {
+  const item = await repository.findById(id);
+  if (!item) {
+    throw new HttpError(404, 'item not found');
+  }
+  return item;
+}

--- a/ttl_server/tests/health.controller.test.ts
+++ b/ttl_server/tests/health.controller.test.ts
@@ -1,0 +1,22 @@
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+
+import app from '../src/app.js';
+import * as healthService from '../src/services/healthService.js';
+
+describe('GET /health', () => {
+  it('returns ok', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('handles service errors', async () => {
+    const spy = vi
+      .spyOn(healthService, 'check')
+      .mockRejectedValue(new Error('boom'));
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(500);
+    spy.mockRestore();
+  });
+});

--- a/ttl_server/tests/items.controller.test.ts
+++ b/ttl_server/tests/items.controller.test.ts
@@ -3,15 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import app from '../src/app.js';
 
-describe('health', () => {
-  it('returns ok', async () => {
-    const res = await request(app).get('/health');
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({ ok: true });
-  });
-});
-
-describe('items/:id', () => {
+describe('GET /items/:id', () => {
   it('returns item on valid id', async () => {
     const id = '123e4567-e89b-12d3-a456-426614174000';
     const res = await request(app).get(`/items/${id}`);
@@ -19,8 +11,14 @@ describe('items/:id', () => {
     expect(res.body).toEqual({ id });
   });
 
-  it('400 on invalid id', async () => {
+  it('returns 400 on invalid id', async () => {
     const res = await request(app).get('/items/not-a-uuid');
     expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when item missing', async () => {
+    const id = '123e4567-e89b-12d3-a456-426614174111';
+    const res = await request(app).get(`/items/${id}`);
+    expect(res.status).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary
- restructure server into routes, controllers, services, repositories and lib
- add request ID logging, Zod validation and centralized error/404 handling
- cover controllers with happy and failure tests

## Testing
- `npm run lint`
- `npm run build`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_68af24d5f748832c9ee3858dca774762