### PR TITLE
feat(server): abstract repositories with in-memory impl

### DIFF
--- a/ttl_server/src/controllers/itemsController.ts
+++ b/ttl_server/src/controllers/itemsController.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 
-import * as itemService from '../services/itemService.js';
 import { createInMemoryItemRepository } from '../repositories/memory/itemRepository.js';
+import * as itemService from '../services/itemService.js';
 
 const itemRepository = createInMemoryItemRepository();
 

--- a/ttl_server/src/controllers/itemsController.ts
+++ b/ttl_server/src/controllers/itemsController.ts
@@ -1,6 +1,9 @@
 import { Request, Response, NextFunction } from 'express';
 
 import * as itemService from '../services/itemService.js';
+import { createInMemoryItemRepository } from '../repositories/memory/itemRepository.js';
+
+const itemRepository = createInMemoryItemRepository();
 
 export async function getItem(
   req: Request,
@@ -9,7 +12,7 @@ export async function getItem(
 ): Promise<void> {
   try {
     const { id } = req.params as { id: string };
-    const item = await itemService.getById(id);
+    const item = await itemService.getById(itemRepository, id);
     res.json(item);
   } catch (err) {
     next(err);

--- a/ttl_server/src/repositories/itemRepository.ts
+++ b/ttl_server/src/repositories/itemRepository.ts
@@ -2,11 +2,6 @@ export interface Item {
   id: string;
 }
 
-const items = new Map<string, Item>();
-items.set('123e4567-e89b-12d3-a456-426614174000', {
-  id: '123e4567-e89b-12d3-a456-426614174000',
-});
-
-export async function findById(id: string): Promise<Item | null> {
-  return items.get(id) ?? null;
+export interface ItemRepository {
+  findById(id: string): Promise<Item | null>;
 }

--- a/ttl_server/src/repositories/memory/itemRepository.ts
+++ b/ttl_server/src/repositories/memory/itemRepository.ts
@@ -1,0 +1,14 @@
+import { Item, ItemRepository } from '../itemRepository.js';
+
+export function createInMemoryItemRepository(): ItemRepository {
+  const items = new Map<string, Item>();
+  items.set('123e4567-e89b-12d3-a456-426614174000', {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+  });
+
+  return {
+    async findById(id: string): Promise<Item | null> {
+      return items.get(id) ?? null;
+    },
+  };
+}

--- a/ttl_server/src/services/itemService.ts
+++ b/ttl_server/src/services/itemService.ts
@@ -1,7 +1,7 @@
 import { HttpError } from '../lib/errors.js';
-import * as repository from '../repositories/itemRepository.js';
+import { ItemRepository } from '../repositories/itemRepository.js';
 
-export async function getById(id: string) {
+export async function getById(repository: ItemRepository, id: string) {
   const item = await repository.findById(id);
   if (!item) {
     throw new HttpError(404, 'item not found');

--- a/ttl_server/tests/item.service.test.ts
+++ b/ttl_server/tests/item.service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { getById } from '../src/services/itemService.js';
+
 import { createInMemoryItemRepository } from '../src/repositories/memory/itemRepository.js';
+import { getById } from '../src/services/itemService.js';
 
 const id = '123e4567-e89b-12d3-a456-426614174000';
 

--- a/ttl_server/tests/item.service.test.ts
+++ b/ttl_server/tests/item.service.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { getById } from '../src/services/itemService.js';
+import { createInMemoryItemRepository } from '../src/repositories/memory/itemRepository.js';
+
+const id = '123e4567-e89b-12d3-a456-426614174000';
+
+describe('itemService.getById', () => {
+  it('returns item when found', async () => {
+    const repo = createInMemoryItemRepository();
+    const item = await getById(repo, id);
+    expect(item).toEqual({ id });
+  });
+
+  it('throws when item not found', async () => {
+    const repo = createInMemoryItemRepository();
+    await expect(getById(repo, 'missing')).rejects.toThrow('item not found');
+  });
+});


### PR DESCRIPTION
## Summary
- define repository interfaces for items
- add in-memory repository implementation
- update services and controllers to use repository abstraction
- add service tests using in-memory repository

## Testing
- `npm run lint` *(fails: ESLint couldn't find @typescript-eslint/eslint-plugin)*
- `npm run build` *(fails: missing type declarations for express and zod)*
- `npm run coverage` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af3dff27ec832c8bf92affcd87b9ed