### PR TITLE
feat(dev): compose + Vite proxy; avoid host port 3000

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -28,22 +28,19 @@ services:
     volumes:
       - ./ttl_server:/app
       - /app/node_modules
-      - ./tsconfig.base.json:/tsconfig.base.json:ro
     command: npm run dev
-    ports: ["3000:3000"]
+    expose: ["3000"]
 
   client:
     build: { context: ./ttl_client, dockerfile: Dockerfile.dev }
     environment:
       NODE_ENV: development
       TZ: Europe/Amsterdam
-      PORT: 5173
       CHOKIDAR_USEPOLLING: "true"
     depends_on: [server]
     volumes:
       - ./ttl_client:/app
       - /app/node_modules
-      - ./tsconfig.base.json:/tsconfig.base.json:ro
     command: npm start
     ports: ["5173:5173"]
 

--- a/ttl_client/README.md
+++ b/ttl_client/README.md
@@ -9,7 +9,7 @@ In the project directory, you can run:
 ### `npm start`
 
 Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Open [http://localhost:5173](http://localhost:5173) to view it in the browser.
 
 The page will reload if you make edits.\
 You will also see any lint errors in the console.

--- a/ttl_client/nginx.conf
+++ b/ttl_client/nginx.conf
@@ -6,9 +6,10 @@ server {
     try_files $uri $uri/ /index.html =404;
   }
   location /api/ {
-    proxy_pass http://server:5000/;
+    proxy_pass http://server:3000/;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 }
-}
+

--- a/ttl_client/package.json
+++ b/ttl_client/package.json
@@ -26,6 +26,6 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
-    "start": "vite"
+    "start": "vite --host 0.0.0.0 --port 5173 --strictPort"
   }
 }

--- a/ttl_client/tsconfig.base.json
+++ b/ttl_client/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "strictNullChecks": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  }
+}

--- a/ttl_client/tsconfig.json
+++ b/ttl_client/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",

--- a/ttl_client/vite.config.ts
+++ b/ttl_client/vite.config.ts
@@ -4,12 +4,17 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: true,
+    port: 5173,
+    strictPort: true,
     proxy: {
       '/api': {
-        target: 'http://server:5000',
+        target: 'http://server:3000',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, '/')
+        secure: false,
+        rewrite: (p) => p.replace(/^\/api/, '')
       }
     }
   }
 });
+

--- a/ttl_server/tsconfig.base.json
+++ b/ttl_server/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "strictNullChecks": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  }
+}

--- a/ttl_server/tsconfig.json
+++ b/ttl_server/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
## Summary
- detach server from host port 3000 and expose internally
- proxy client requests through Vite and copy tsconfig base into packages

## Testing
- `npm run lint`
- `npm run build`
- `npm run coverage`

## Checklist
- [ ] Host bindt 3000 niet.
- [ ] Client toont UI op 5173.
- [ ] Proxy /api → server:3000 werkt.
- [ ] Alle “localhost:3000” vervangen door /api.
- [ ] TS-configs per package (extends: ./tsconfig.base.json).

## Self-check
- [x] `npm run lint` is groen.
- [x] `npm run build` is groen.
- [x] `npm run coverage` haalt drempels.
- [x] Geen `any` in nieuwe/gewijzigde TS-bestanden.
- [x] Geen secrets toegevoegd.
- [x] Map- en laag-structuur gevolgd.
- [x] Tests dekken nieuw publiek gedrag.


------
https://chatgpt.com/codex/tasks/task_e_68af67e7c6b0832c827328c765e42625